### PR TITLE
fix home field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "coding-coach",
   "version": "0.1.0",
   "private": true,
-  "homepage": "http://coding-coach.github.io/",
+  "homepage": "https://codingcoach.io/",
   "dependencies": {
     "classnames": "^2.2.6",
     "i18next": "^11.7.0",


### PR DESCRIPTION
## Description

Currently the home field in `package.json` points to http://coding-coach.github.io/ which points to 404 page. I've made the change to https://codingcoach.io/

## Issue

#68 Package.json homepage
