### PR TITLE
fix: properly size image using object-fit: cover

### DIFF
--- a/src/containers/App/assets/app.scss
+++ b/src/containers/App/assets/app.scss
@@ -14,6 +14,7 @@
   left: 0;
   z-index: -1;
   min-width: 900px;
+  object-fit: cover;
 }
 
 .header {


### PR DESCRIPTION
# Details

## Description

Currently the image is skewed depending on the viewport. This partly fixes it. A better alternative solution would be to use `background-image` + `background-size: cover`.

## Steps to QA

<!-- IF UNNECESSARY, REMOVE THIS SECTION. OTHERWISE, LIST STEPS SOMEONE CAN TAKE TO QA THE FEATURE OR BUG. -->

- [ ] resize the viewport and check the image