### PR TITLE
security: disconnect new windows from parent window (tab nabbing)

### DIFF
--- a/src/components/contact/SocialMedia.jsx
+++ b/src/components/contact/SocialMedia.jsx
@@ -8,17 +8,17 @@ const SocialMedia = () => {
   return (
     <div className={styles.social_media}>
       <div className={styles.icon_wrapper}>
-        <a target="_blank" href={process.env.REACT_APP_FB_URL}>
+        <a target="_blank" href={process.env.REACT_APP_FB_URL} rel="noreferrer noopener">
           <FontAwesomeIcon icon={faFacebook} size='2x' className={styles.green_icons} />
         </a>
       </div>
       <div className={styles.icon_wrapper}>
-        <a target="_blank" href={process.env.REACT_APP_INSTA_URL}>
+        <a target="_blank" href={process.env.REACT_APP_INSTA_URL} rel="noreferrer noopener">
           <FontAwesomeIcon icon={faInstagram} size='2x' className={styles.green_icons} />
         </a>
       </div>
       <div className={styles.icon_wrapper}>
-        <a target="_blank" href={process.env.REACT_APP_TWITTER_URL}>
+        <a target="_blank" href={process.env.REACT_APP_TWITTER_URL} rel="noreferrer noopener">
           <FontAwesomeIcon icon={faTwitter} size='2x' className={styles.green_icons} />
         </a>
       </div>


### PR DESCRIPTION
# Details

## Description

In general it is good to use `rel="noopener"` on external links to cut the connection between the original widow and the newly created tabs.

See https://mathiasbynens.github.io/rel-noopener/
