### PR TITLE
Fix / svgs not loading on storybook, inconsistencies in refactoring while font-size variables were declared as per #72

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -8,7 +8,11 @@ module.exports = (storybookBaseConfig, configType) => {
       include: path.resolve(__dirname, '..', 'src'),
     },
     {
-      test: /\.(png|jpg|gif)$/,
+      
+      // test: /\.(png|jpg|gif)$/,
+      /** the above line caused svgs to not load when we are running storyboard.
+       *  So added svg along with some font formats just in case. */
+      test: /\.(woff|woff2|eot|ttf|svg|gif|png|jpg)$/,
       use: [
         {
           loader: 'file-loader',

--- a/src/components/contact/assets/contact.scss
+++ b/src/components/contact/assets/contact.scss
@@ -24,7 +24,7 @@ section.contact {
     width: 50%;
     margin-left: auto;
     text-align: right;
-    font-size: $font-giant;
+    font-size: $font-xl;
     color: $green300;
     text-transform: uppercase;
     border-bottom: 1px solid $gray;


### PR DESCRIPTION
# Details

## Description

**1) The svg in the contact form was not loading in the storybook and was throwing an error.**

```
ERROR in ./src/components/contact/assets/people-search.svg
Module parse failed: Unexpected token (1:0)
You may need an appropriate loader to handle this file type.
| <svg id="80df28fc-b448-4013-8ee3-62e531de40a8" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1113.61" height="844.14" viewBox="0 0 1113.61 844.14"><defs><linearGradient id="94ea2f64-8775-4285-9535-47505d4504ba" x1="514.28" y1="794.6" x2="514.28" y2="39.29" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="gray" stop-opacity="0.25"/><stop offset="0.54" stop-color="gray" stop-opacity="0.12"/><stop offset="1" stop-color="gray" stop-opacity="0.1"/></linearGradient><linearGradient id
...
```


seems like the appropriate loader were not specified. Added loader for svgs and some popular font formats just in case we need them in future.

**2) variable `$font-xl` was typoed as `$font-giant` (or got missed in refactoring not sure which one)**
