### PR TITLE
Update Travis badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # coding-coach
-[![Build Status](https://travis-ci.org/coding-coach/coding-coach.svg?branch=development)](https://travis-ci.org/coding-coach/coding-coach)
+[![Build Status](https://api.travis-ci.org/Coding-Coach/coding-coach.svg?branch=development)](https://travis-ci.org/Coding-Coach/coding-coach)
 
 Connecting developers with mentors worldwide.
 


### PR DESCRIPTION
## Details

### Description

<!-- ADD A DETAILED DESCRIPTION OF THE PULL REQUEST AND WHAT IT INTENDS TO SOLVE. -->
Travis build is working fine now, but I found that Travis badge in readme was still showing unknown. After some debugging, I found that issue was that the Travis badge image link had a small typo. I have fixed it.

### Issue

<!-- IF UNNECESSARY, REMOVE THIS SECTION. OTHERWISE, REFERENCE THE GITHUB ISSUE, OR ISSUES, THIS PR PERTAINS TO. -->
Closes #76