### PR TITLE
Feature: Add Panel to body when opened as modal

### DIFF
--- a/src/components/panel/Panel.js
+++ b/src/components/panel/Panel.js
@@ -1,4 +1,5 @@
 import React, { cloneElement } from 'react';
+import ReactDOM from 'react-dom';
 import { node, func, bool, object } from 'prop-types';
 import classNames from 'classnames/bind';
 import styles from './assets/panel.scss';
@@ -8,6 +9,7 @@ import Footer from './PanelFooter';
 import { noop } from 'utils/noop';
 
 const cx = classNames.bind(styles);
+const body = document.querySelector('body');
 
 /**
  * Usage:
@@ -65,11 +67,7 @@ export default class Panel extends React.Component {
   constructor(props) {
     super(props);
     this.state = { ...Panel.defaultProps };
-
-    // event handlers hard bound to this
-    // this.handleTriggerClick = this.handleTriggerClick.bind(this);
-    // this.handleCloseIconClick = this.handleCloseIconClick.bind(this);
-    // this.handleEscape = this.handleEscape.bind(this);
+    this.el = document.createElement('div');
   }
 
   componentWillReceiveProps({ open }) {
@@ -88,6 +86,7 @@ export default class Panel extends React.Component {
 
   handleTriggerClick = () => {
     this.setState({ open: true });
+    body.appendChild(this.el);
   };
 
   handleEscape = (e) => {
@@ -109,6 +108,7 @@ export default class Panel extends React.Component {
     onClose(event);
 
     this.setState({ open: false });
+    body.removeChild(this.el);
   }
 
   renderCloseIcon() {
@@ -135,14 +135,17 @@ export default class Panel extends React.Component {
       modal && trigger
         ? cloneElement(trigger, { onClick: this.handleTriggerClick, key: 'trigger' })
         : null,
-      modal && open ? (
-        <div className={rootClasses} key="modal">
-          <section className={mainSectionClasses}>
-            {this.renderCloseIcon()}
-            {children}
-          </section>
-        </div>
-      ) : null,
+      modal && open
+        ? ReactDOM.createPortal(
+            <div className={rootClasses} key="modal">
+              <section className={mainSectionClasses}>
+                {this.renderCloseIcon()}
+                {children}
+              </section>
+            </div>,
+            this.el,
+          )
+        : null,
       !modal ? (
         <section className={mainSectionClasses} key="panel">
           {children}

--- a/src/components/panel/__tests__/Panel.test.js
+++ b/src/components/panel/__tests__/Panel.test.js
@@ -38,7 +38,7 @@ test('Rendered modal Panel should open the modal when trigger element is clicked
 
 test('Rendered modal should close when x icon is clicked', async() => {
   const handleClick = jest.fn();
-  const { queryByText, container } = render(
+  const { queryByText, container, debug } = render(
     <Panel onClose={handleClick} trigger={<button>Open Panel</button>} closable={true} modal={true}>
       A basic Panel
     </Panel>,
@@ -49,7 +49,7 @@ test('Rendered modal should close when x icon is clicked', async() => {
   fireEvent.click(triggerBtn);
   const panel = await waitForElement(() => queryByText('A basic Panel'));
 
-  const closeIcon = container.querySelector('i');
+  const closeIcon = document.querySelector('i');
   fireEvent.click(closeIcon);
   expect(handleClick).toHaveBeenCalledTimes(1);
   await wait(() => expect(queryByText(/A basic Panel/i)).not.toBeInTheDocument());


### PR DESCRIPTION
# Details

## Description
Right now the panel is mounted in component from where its called. It dosen't make sense to mount the panel inside the component when opened as a modal.

I have used [ReactDOM's portal](https://reactjs.org/docs/portals.html) to mount the panel in the body.

## Screenshots
Panel mounted inside the component
<img width="569" alt="screen shot 2018-10-19 at 7 49 09 pm" src="https://user-images.githubusercontent.com/2995641/47224026-30cdf200-d3d8-11e8-8f13-0e5d25e1a081.png">

Panel mounted at the end of the body
<img width="596" alt="screen shot 2018-10-19 at 7 53 53 pm" src="https://user-images.githubusercontent.com/2995641/47224293-ce292600-d3d8-11e8-8b2a-d88d0fcc860e.png">



