### PR TITLE
[FEATURE] Adding common spacing classes

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -1,4 +1,5 @@
 @import '~theme/base/variables';
+@import '~theme/base/spacing';
 
 .button {
   display: inline-block;
@@ -104,31 +105,31 @@
     text-shadow: none;
   }
 
-
-  &.default {
-    padding: 0px $font-s;
-  }
-
-  &.large {
-    padding: 0px $font-l;
-    min-height: $button-large;
-    line-height: $button-large;
-    font-size: $font-l;
-  }
-
-  &.small {
-    padding: 0px $font-xs;
-    min-height: $button-small;
-    line-height: $button-small;
-    font-size: $font-xxs
-  }
-  &.fullWidth {
-    width: 100%;
-  }
-
   // For icons and svgs
   i, svg {
     vertical-align: middle;
     margin-right: 4px;
   }
+}
+
+.default {
+  composes: PHM;
+}
+
+.large {
+  composes: PHL;
+  min-height: $button-large;
+  line-height: $button-large;
+  font-size: $font-l;
+}
+
+.small {
+  composes: PHS;
+  min-height: $button-small;
+  line-height: $button-small;
+  font-size: $font-xxs
+}
+
+.fullWidth {
+  width: 100%;
 }

--- a/src/components/footer/footer.scss
+++ b/src/components/footer/footer.scss
@@ -1,21 +1,22 @@
 @import '~theme/base/variables';
 @import '~theme/base/mediaqueries';
 @import '~theme/base/utils';
+@import '~theme/base/spacing';
 
 .footerMain {
   width: 100%;
 }
 
 .footerInner {
+  composes: PVS;
   @include generalAlignment();
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 10px 0;
   border-top: 1px solid $color-grey-light;
-  margin: 0 10px;
   
   @include respond-to(tablet) {
+    @include spacing('P', 'V', 'M');
     flex-direction: row;
     margin-left: 30px;
     margin-right: 30px;

--- a/src/components/navbar/navbar.scss
+++ b/src/components/navbar/navbar.scss
@@ -1,17 +1,10 @@
 @import "~theme/base/variables";
 @import '~theme/base/utils';
+@import '~theme/base/spacing';
 
 .navigationBar {
-  padding: 1em 0;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: index(menu);
-
-  @include respond-to(tablet) {
-    padding: 1.25em 0;
-  }
+  composes: PVM;
+  background-color: $color-secondary;
 }
 
 .inner {

--- a/src/components/overlayCookie/overlayCookie.scss
+++ b/src/components/overlayCookie/overlayCookie.scss
@@ -14,7 +14,7 @@
 
 .cookieContent {
   display: flex;
-  @include generalAlignment()
+  @include generalAlignment();
   color: $color-grey-dark;
   font-size: $font-xxs;
   justify-content: space-between;

--- a/src/pages/home/Home.js
+++ b/src/pages/home/Home.js
@@ -1,8 +1,10 @@
 import React, { Fragment } from 'react';
 import { translate, Interpolate } from 'react-i18next';
+import { noop } from 'utils/noop';
 import 'i18n/i18n';
 
 import styles from './assets/home.scss';
+import Button from 'components/button/Button';
 import Navbar from 'components/navbar/Navbar';
 import Image from 'components/image/Image';
 import HomeSection from './components/HomeSection';
@@ -38,7 +40,9 @@ function Home({ t }) {
               <span>{t('home-header-title')}</span>
             </h1>
             <h2 className={styles.heroSubtitle}>{t('home-header-subtitle')}</h2>
-            <button className={styles.callToAction}>{t('home-header-cta')}</button>
+            <Button onClick={noop} className={styles.callToAction}>
+              {t('home-header-cta')}
+            </Button>
           </header>
           <Image className={styles.heroImage} alt={t('home-header-media-alt')} src={heroImage} />
         </div>

--- a/src/pages/home/assets/home.scss
+++ b/src/pages/home/assets/home.scss
@@ -1,169 +1,149 @@
 @import '~theme/base/variables';
 @import '~theme/base/mediaqueries';
 @import '~theme/base/utils';
+@import '~theme/base/spacing';
 
 $distance-height-variation-before: 20px;
 $distance-height-variation-after: 40px;
 
 // Sections with the text at the right
 @mixin isReverseSection() {
-    text-align: right;
+  text-align: right;
 
-    header {
-        &:after {
-            right: 0;
-        }
+  header {
+    &:after {
+      right: 0;
     }
+  }
 
-    @include respond-to(tablet) {
-        > div {
-            flex-direction: row-reverse;
-        }
+  @include respond-to(tablet) {
+    > div {
+      flex-direction: row-reverse;
     }
+  }
 }
 
 .hero {
-    position: relative;
-    min-height: 50vh;
-    padding-top: 5rem;
-    padding-bottom: 5rem;
+  composes: PVXL;
+  position: relative;
+  min-height: 50vh;
 
-    @include respond-to(tablet) {
-        min-height: 550px;
-        padding-top: 6rem;
-        padding-bottom: 6rem;
-    }
+  @include respond-to(tablet) {
+    min-height: 550px;
+  }
 
-    &:before {
-      content: '';
-      position: absolute;
-      background: $color-secondary;
-      top: 0;
-      height: 100%;
-      width: 100%;
-      z-index: index(background) - 1;
-    }
+  &:before {
+    content: '';
+    position: absolute;
+    background: $color-secondary;
+    top: 0;
+    height: 100%;
+    width: 100%;
+    z-index: index(background) - 1;
+  }
 
-    &:after {
-        content: '';
-        position: absolute;
-        bottom: 0;
-        background-image: linear-gradient(to bottom right, $color-secondary 50%, $color-white 50%);
-        height: 20%;
-        width: 100%;
-        z-index: index(background);
-    }
+  &:after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    background-image: linear-gradient(to bottom right, $color-secondary 50%, $color-white 50%);
+    height: 20%;
+    width: 100%;
+    z-index: index(background);
+  }
 }
 
 .heroInner {
-    @include generalAlignment();
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  @include generalAlignment();
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .heroTextWrapper {
-    @include respond-to(tablet) {
-        width: 50%;
-    }
+  @include respond-to(tablet) {
+    width: 50%;
+  }
 }
 
 .heroTitle {
-    color: $color-white;
-    font-family: $font-secondary;
-    font-size: $font-xxxl;
-    font-weight: $font-bold;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    line-height: 1.125;
-    margin: 0;
+  color: $color-white;
+  font-family: $font-secondary;
+  font-size: $font-xxxl;
+  font-weight: $font-bold;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  line-height: 1.125;
+  margin: 0;
 
-    width: min-intrinsic;
-    width: -webkit-min-content;
-    width: -moz-min-content;
-    width: min-content;
+  width: min-intrinsic;
+  width: -webkit-min-content;
+  width: -moz-min-content;
+  width: min-content;
 }
 
 .heroSubtitle {
-    color: $color-white;
-    font-family: $font-primary;
-    font-size: $font-l;
-    font-weight: $font-thin;
-    margin: 0 0 1.25rem 0;
-}
-
-.callToAction {
-    text-decoration: none;
-    border-radius: $border-radius-rounded;
-    padding: 0.75rem 2rem;
-    font-family: $font-primary;
-    font-size: $font-s;
-    border: 0px;
-    text-transform: uppercase;
-    color: $color-white;
-    background-color: $color-primary;
-    box-shadow: 0px 1px 5px 0px rgba(0, 0, 0, 0.2);
-
-    &:hover, &:focus {
-        background-color: $color-primary-darker;
-        transition: 0.25s ease all;
-    }
+  composes: MTZ;
+  composes: MBM;
+  color: $color-white;
+  font-family: $font-primary;
+  font-size: $font-l;
+  font-weight: $font-thin;
 }
 
 .heroImage {
-    display: none;
-    width: 350px;
+  display: none;
+  width: 350px;
 
-    @include respond-to(tablet) {
-        display: block;
-        width: 45%;
-    }
+  @include respond-to(tablet) {
+    display: block;
+    width: 45%;
+  }
 }
 
 .content {
-    > section:nth-child(odd) {
-        background-color: $color-white;
-        h1 {
-            color: $color-secondary;
-        }
-        @include isReverseSection();
+  > section:nth-child(odd) {
+    background-color: $color-white;
+    h1 {
+      color: $color-secondary;
+    }
+    @include isReverseSection();
+  }
 
+  > section:nth-child(2) {
+    background-color: $color-tertiary;
+
+    &:before,
+    &:after {
+      content: "";
+      background: $color-tertiary;
+      width: 100%;
+      position: absolute;
+      left: 0;
     }
 
-    > section:nth-child(2) {
-        background-color: $color-tertiary;
-
-        &:before,
-        &:after {
-            content: "";
-            background: $color-tertiary;
-            width: 100%;
-            position: absolute;
-            left: 0;
-        }
-
-        &:before {
-            height: $distance-height-variation-before;
-            top: -$distance-height-variation-before;
-            background: linear-gradient(to top right, $color-tertiary, $color-tertiary 50%, white 50%, white);
-        }
-
-        &:after {
-            height: $distance-height-variation-after;
-            bottom: -$distance-height-variation-after;
-            background: linear-gradient(to bottom left, $color-tertiary, $color-tertiary 50%, white 50%, white);
-        }
+    &:before {
+      height: $distance-height-variation-before;
+      top: -$distance-height-variation-before;
+      background: linear-gradient(to top right, $color-tertiary, $color-tertiary 50%, white 50%, white);
     }
 
-    > section:last-child {
-      //margin and padding adjustements are needed to render background color diagonally
-        margin-top: 160px;
-        padding-top: 0;
-        p {
-          font-size: $font-s;
-          color: $color-grey-medium;
-        }
+    &:after {
+      height: $distance-height-variation-after;
+      bottom: -$distance-height-variation-after;
+      background: linear-gradient(to bottom left, $color-tertiary, $color-tertiary 50%, white 50%, white);
     }
+  }
+
+  > section:last-child {
+    //margin and padding adjustements are needed to render background color diagonally
+    margin-top: 160px;
+    padding-top: 0;
+    p {
+      font-size: $font-s;
+      color: $color-grey-medium;
+    }
+  }
 }
 
 .email {

--- a/src/theme/base/_spacing.scss
+++ b/src/theme/base/_spacing.scss
@@ -41,10 +41,10 @@ $directionListHorizontal: (
 // L - large
 // XL - Extra large
 $sizeList: (
-  'a': 'auto',
+  'A': 'auto',
   'Z': 0,
   'T': 1px,
-  'E': 4px,
+  'XS': 4px,
   'S': 8px,
   'M': 16px,
   'L': 32px,

--- a/src/theme/base/_spacing.scss
+++ b/src/theme/base/_spacing.scss
@@ -33,13 +33,14 @@ $directionListHorizontal: (
 );
 
 // Size list description:
+// A - auto
 // Z - zero
 // T - tiny
-// E - extra small
+// XS - extra small
 // S - small
 // M - medium
 // L - large
-// XL - Extra large
+// XL - extra large
 $sizeList: (
   'A': 'auto',
   'Z': 0,

--- a/src/theme/base/_spacing.scss
+++ b/src/theme/base/_spacing.scss
@@ -1,3 +1,20 @@
+/**
+ * We need a way to consistently set the spacing in the app. This script
+ * generates classnames for paddings and margins. It also defines a mixin to
+ * use inside responsive selectors.
+ *
+ * The idea is to use composition when possible, for responsive scenarios we should use
+ * the `spacing` mixing.
+ *
+ * The classnames consist of three parts, representing the following:
+ *
+ *  .[Type][Direction][Size]
+ *
+ *  Type = `M` or `P` = Margin or Padding
+ *  Direction = `T`, `L`, `R`, `B` = Top, Left, Right, Bottom
+ *  Size = `Z`, `T`, `S`, `M`, `L`, `XL` = Zero, Tiny, Small, Medium, Large, Extra Large
+ *
+ **/
 $typeList: (
   'M': 'margin',
   'P': 'padding',
@@ -35,8 +52,41 @@ $sizeList: (
   'XXL': 84px,
 );
 
+/**
+ * Composition doesn't work well inside responsive selectors, therefore we
+ * should use this mixing instead to still keep consistency across our code base.
+ * 
+ *  .button {
+ *    // some styles for mobile
+ *
+ *    respond-to(tablet) {
+ *      @include spacing('M', 'L', 'XL'); // marging-left: 64px;
+ *      // something else....
+ *    }
+ *  }
+ */
+@mixin spacing($type: 'P', $direction: 'V', $size: 'M') {
+  $directions: map-get($directionListVertical, $direction);
 
-@mixin spacing($types, $directions, $sizes) {
+  @if ($directions) { } @else {
+    $directions: map-get($directionListHorizontal, $direction);
+  }
+
+  @each $dir in $directions {
+    #{map-get($typeList, $type) + '-' + $dir}: #{map-get($sizeList, $size)};
+  }
+}
+
+/**
+ * Generates the common spacing classes for composition.
+ *
+ *  .button {
+ *    composes: PTM; // padding-top: 16px;
+ *    composes: MLL; // margin-left: 32px;
+ *  }
+ *
+ */
+@mixin spacingGenerator($types, $directions, $sizes) {
   @each $typeKey, $type in $types {
     @each $directionKey, $direction in $directions {
       @each $sizeKey, $size in $sizes {
@@ -50,5 +100,5 @@ $sizeList: (
   }
 }
 
-@include spacing($typeList, $directionListVertical, $sizeList);
-@include spacing($typeList, $directionListHorizontal, $sizeList);
+@include spacingGenerator($typeList, $directionListVertical, $sizeList);
+@include spacingGenerator($typeList, $directionListHorizontal, $sizeList);

--- a/src/theme/base/_spacing.scss
+++ b/src/theme/base/_spacing.scss
@@ -1,0 +1,53 @@
+$typeList: (
+  'M': 'margin',
+  'P': 'padding',
+);
+
+$directionListVertical: (
+  'T': ('top'),
+  'B': ('bottom'),
+  'V': ('top', 'bottom'),
+);
+
+$directionListHorizontal: (
+  'L': ('left'),
+  'R': ('right'),
+  'H': ('left', 'right'),
+);
+
+// Size list description:
+// Z - zero
+// T - tiny
+// E - extra small
+// S - small
+// M - medium
+// L - large
+// XL - Extra large
+$sizeList: (
+  'a': 'auto',
+  'Z': 0,
+  'T': 1px,
+  'E': 4px,
+  'S': 8px,
+  'M': 16px,
+  'L': 32px,
+  'XL': 64px,
+);
+
+
+@mixin spacing($types, $directions, $sizes) {
+  @each $typeKey, $type in $types {
+    @each $directionKey, $direction in $directions {
+      @each $sizeKey, $size in $sizes {
+        .#{$typeKey}#{$directionKey}#{$sizeKey} {
+          @each $dir in $direction {
+            #{$type + '-' + $dir}: #{$size};
+          }
+        }
+      }
+    }
+  }
+}
+
+@include spacing($typeList, $directionListVertical, $sizeList);
+@include spacing($typeList, $directionListHorizontal, $sizeList);

--- a/src/theme/base/_spacing.scss
+++ b/src/theme/base/_spacing.scss
@@ -32,6 +32,7 @@ $sizeList: (
   'M': 16px,
   'L': 32px,
   'XL': 64px,
+  'XXL': 84px,
 );
 
 


### PR DESCRIPTION
# Details

## Description
We need a way to consistently set the spacing in the app. This PRs introduces a script to generate classnames for paddings and margins.

The idea is to use composition when possible, for responsive scenarios we should use the `spacing` mixing.

These is the list of available sizes:
```
// Size list description:
// Z - zero
// T - tiny
// E - extra small
// S - small
// M - medium
// L - large
// XL - Extra large
$sizeList: (
  'a': 'auto',
  'Z': 0,
  'T': 1px,
  'E': 4px,
  'S': 8px,
  'M': 16px,
  'L': 32px,
  'XL': 64px,
  'XXL': 84px,
);
```

The classnames usually consist of three characters, one representing the following: **[Margin | Padding][Direction][Size]**, for example: MBL or PTS;

`M` or `P` = Margin or Padding
`T`, `L`, `R`, `B` = Direction: Top, Left, Right, Bottom
`Z`, `T`, `S`, `M`, `L`, `XL` = Zero, Tiny, Small, Medium, Large, Extra Large

Usage:
```
@import '~theme/base/spacing'; // Import the classes

.button {
  composes: PTM; // padding-top: 16px;
  composes: MLL; // margin-left: 32px;
}
```

Internally the css loader will reuse the existing classes, so instead of creating new styles we will reuse the existing. The tradeoff of composition is that we can't use it inside media queries, but to solve that problem we can use the `spacing` mixing to define consistent margins and paddings.

```
.button {
  composes: PTM; // padding-top: 16px;
  composes: MLL; // margin-left: 32px;

  respond-to(tablet) {
    @include spacing('M', 'L', 'XL'); // marging-left: 64px;
  }
}
```