### PR TITLE
Add rel='noopener noreferrer' to the links that were not using it

### DIFF
--- a/src/pages/home/components/Contact.js
+++ b/src/pages/home/components/Contact.js
@@ -11,7 +11,12 @@ import SocialMedia from './SocialMedia';
 
 const Contact = ({ t }) => {
   const emailLink = (
-    <a target="_blank" href={`mailto:${config.contact.EMAIL}`} className={styles.email}>
+    <a
+      target="_blank"
+      href={`mailto:${config.contact.EMAIL}`}
+      className={styles.email}
+      rel="noopener noreferrer"
+    >
       {config.contact.EMAIL}
     </a>
   );


### PR DESCRIPTION
# Details
Since people could do fishing with links that have the `target=_blank` we should prevent of this.
We could do it adding rel="noreferrer noopener"

## Issue

https://github.com/Coding-Coach/coding-coach/issues/163