### PR TITLE
[FIX] Showing up the cookies disclaimer

### DIFF
--- a/src/components/footer/Footer.js
+++ b/src/components/footer/Footer.js
@@ -2,103 +2,37 @@ import React from 'react';
 import { translate } from 'react-i18next';
 import 'i18n/i18n';
 
-import Modal from 'components/modal/Modal';
-import { Panel, PanelHeader, PanelContent, PanelFooter } from 'components/panel/Panel';
-import { PrivacyPolicy } from 'pages/static/PrivacyPolicy';
-import { CookiesPolicy } from 'pages/static/CookiesPolicy';
-import { TermsAndConditions } from 'pages/static/TermsAndConditions';
-import Button from 'components/button/Button';
 import DonateButton from './DonateButton';
 import styles from './footer.scss';
 
-const classesPanel = { panelRoot: styles.panelRoot };
-
-class Footer extends React.Component {
-  state = {
-    modal: {
-      show: false,
-      option: undefined,
-    },
-  };
-
-  openModal = (option) => {
-    this.setState({
-      modal: {
-        show: true,
-        option: option,
-      },
-    });
-  };
-
-  toggleModal = () => this.setState({ modal: { show: !this.state.modal.show } });
-
-  renderModalByOption = (option, t) => {
-    return (
-      <Modal onClose={this.toggleModal}>
-        <Panel classes={classesPanel}>
-          <PanelHeader>{t(`footer-${option}`)}</PanelHeader>
-          <PanelContent>{this.getContentByOption(option)}</PanelContent>
-          <PanelFooter>
-            <Button size="small" onClick={this.toggleModal}>
-              {t('close')}
-            </Button>
-          </PanelFooter>
-        </Panel>
-      </Modal>
-    );
-  };
-
-  getContentByOption = (option) => {
-    switch (option) {
-      case 'terms-and-conditions':
-        return <TermsAndConditions />;
-      case 'cookies':
-        return <CookiesPolicy />;
-      case 'privacy-policy':
-        return <PrivacyPolicy />;
-      default:
-        return null;
-    }
-  };
-
-  render() {
-    const { t } = this.props;
-    const { modal } = this.state;
-
-    return (
-      <footer className={styles.footerMain}>
-        <div className={styles.footerInner}>
-          <div className={styles.column}>
-            <DonateButton />
-          </div>
-
-          {modal.show && this.renderModalByOption(modal.option, t)}
-
-          <a
-            onClick={() => this.openModal('terms-and-conditions')}
-            href={'#terms'}
-            className={styles.footerLink}
-          >
-            {t('footer-terms-and-conditions')}
-          </a>
-          <a
-            onClick={() => this.openModal('cookies')}
-            href={'#cookies'}
-            className={styles.footerLink}
-          >
-            {t('footer-cookies')}
-          </a>
-          <a
-            onClick={() => this.openModal('privacy-policy')}
-            href={'#privacy'}
-            className={styles.footerLink}
-          >
-            {t('footer-privacy-policy')}
-          </a>
+function Footer({ onClickLegal, t }) {
+  return (
+    <footer className={styles.footerMain}>
+      <div className={styles.footerInner}>
+        <div className={styles.column}>
+          <DonateButton />
         </div>
-      </footer>
-    );
-  }
+
+        <a
+          onClick={() => onClickLegal('terms-and-conditions')}
+          href={'#terms'}
+          className={styles.footerLink}
+        >
+          {t('legal-terms-and-conditions')}
+        </a>
+        <a onClick={() => onClickLegal('cookies')} href={'#cookies'} className={styles.footerLink}>
+          {t('legal-cookies')}
+        </a>
+        <a
+          onClick={() => onClickLegal('privacy-policy')}
+          href={'#privacy'}
+          className={styles.footerLink}
+        >
+          {t('legal-privacy-policy')}
+        </a>
+      </div>
+    </footer>
+  );
 }
 
 export default translate('translations')(Footer);

--- a/src/components/footer/footer.scss
+++ b/src/components/footer/footer.scss
@@ -60,7 +60,3 @@
     }
   }
 }
-
-.panelRoot {
-  height: 100%;
-}

--- a/src/components/overlayCookie/OverlayCookie.js
+++ b/src/components/overlayCookie/OverlayCookie.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { func } from 'prop-types';
 import { translate } from 'react-i18next';
 import 'i18n/i18n';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -8,6 +9,10 @@ import styles from './overlayCookie.scss';
 class OverlayCookie extends Component {
   state = {
     cookiesAccepted: 'false',
+  };
+
+  static propTypes = {
+    onReadMore: func.isRequired,
   };
 
   acceptCookies = () => {
@@ -36,7 +41,7 @@ class OverlayCookie extends Component {
 
   render() {
     const { cookiesAccepted } = this.state;
-    const { t } = this.props;
+    const { onReadMore, t } = this.props;
 
     if (cookiesAccepted === true) return null;
 
@@ -46,7 +51,9 @@ class OverlayCookie extends Component {
           <p className={styles.cookieText}>
             {t('cookie-notification') + ' '}
             <span>
-              <a href="#cookies">{t('cookie-link')}</a>
+              <a href="#cookies" onClick={() => onReadMore('cookies')}>
+                {t('cookie-link')}
+              </a>
             </span>
           </p>
           <p className={styles.cookieIcon}>

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -4,9 +4,9 @@ export default function loadEn() {
       'cookie-notification':
         'To help personalize content, tailor and measure ads, and provide a safer experience, we use cookies. By clicking or navigating the site, you agree to allow our collecion of information on and off Coding Coach through cookies. Learn more, including about available controls:',
       'cookie-link': 'Cookies Policy',
-      'footer-terms-and-conditions': 'Terms & Conditions',
-      'footer-cookies': 'Cookies',
-      'footer-privacy-policy': 'Privacy Policy',
+      'legal-terms-and-conditions': 'Terms & Conditions',
+      'legal-cookies': 'Cookies',
+      'legal-privacy-policy': 'Privacy Policy',
       'footer-donate': 'Donate!',
       'footer-donate-paypal': 'PayPal - The safer, easier way to pay online!',
       'home-header-title': 'Coding Coach',

--- a/src/pages/home/Home.js
+++ b/src/pages/home/Home.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Component, Fragment } from 'react';
 import { translate, Interpolate } from 'react-i18next';
 import 'i18n/i18n';
 
@@ -7,9 +7,10 @@ import Button from 'components/button/Button';
 import Navbar from 'components/navbar/Navbar';
 import Image from 'components/image/Image';
 import OverlayCookie from 'components/overlayCookie/OverlayCookie';
+import Footer from 'components/footer/Footer';
+import LegalModal from './components/LegalModal';
 import HomeSection from './components/HomeSection';
 import SocialMedia from './components/SocialMedia';
-import Footer from 'components/footer/Footer';
 import ImageAbout from './assets/images/about.svg';
 import ImageMission from './assets/images/mission.svg';
 import ImageContact from './assets/images/contact.svg';
@@ -18,15 +19,32 @@ import config from 'config/constants';
 
 const heroImage = require('./assets/images/coding-coach-logo.svg');
 
-class Home extends React.Component {
+class Home extends Component {
+  state = {
+    legal: {
+      page: undefined,
+      show: false,
+    },
+  };
+
   handleOnClickCTA = () => {
     document.getElementById('about').scrollIntoView({
       behavior: 'smooth',
     });
   };
 
+  toggleModal = (page) => {
+    this.setState({
+      legal: {
+        show: !this.state.legal.show,
+        page,
+      },
+    });
+  };
+
   render() {
     const { t } = this.props;
+    const { legal } = this.state;
 
     return (
       <Fragment>
@@ -86,8 +104,9 @@ class Home extends React.Component {
             <SocialMedia />
           </HomeSection>
         </main>
-        <Footer />
-        <OverlayCookie />
+        <Footer onClickLegal={this.toggleModal} />
+        <OverlayCookie onReadMore={this.toggleModal} />
+        {legal.show && <LegalModal page={legal.page} onClose={this.toggleModal} />}
       </Fragment>
     );
   }

--- a/src/pages/home/Home.js
+++ b/src/pages/home/Home.js
@@ -6,6 +6,7 @@ import styles from './assets/home.scss';
 import Button from 'components/button/Button';
 import Navbar from 'components/navbar/Navbar';
 import Image from 'components/image/Image';
+import OverlayCookie from 'components/overlayCookie/OverlayCookie';
 import HomeSection from './components/HomeSection';
 import SocialMedia from './components/SocialMedia';
 import Footer from 'components/footer/Footer';
@@ -86,6 +87,7 @@ class Home extends React.Component {
           </HomeSection>
         </main>
         <Footer />
+        <OverlayCookie />
       </Fragment>
     );
   }

--- a/src/pages/home/components/LegalModal.js
+++ b/src/pages/home/components/LegalModal.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { func, oneOf } from 'prop-types';
+import { translate } from 'react-i18next';
+import 'i18n/i18n';
+
+import Button from 'components/button/Button';
+import Modal from 'components/modal/Modal';
+import { Panel, PanelHeader, PanelContent, PanelFooter } from 'components/panel/Panel';
+import { PrivacyPolicy } from 'pages/static/PrivacyPolicy';
+import { CookiesPolicy } from 'pages/static/CookiesPolicy';
+import { TermsAndConditions } from 'pages/static/TermsAndConditions';
+import styles from './LegalModal.scss';
+
+const classesPanel = { panelRoot: styles.panelRoot };
+
+function LegalModal({ onClose, page, t }) {
+  let Content = CookiesPolicy;
+
+  if (page === 'terms-and-conditions') {
+    Content = TermsAndConditions;
+  }
+
+  if (page === 'privacy-policy') {
+    Content = PrivacyPolicy;
+  }
+
+  return (
+    <Modal onClose={onClose}>
+      <Panel classes={classesPanel}>
+        <PanelHeader>{t(`legal-${page}`)}</PanelHeader>
+        <PanelContent>
+          <Content />
+        </PanelContent>
+        <PanelFooter>
+          <Button size="small" onClick={onClose}>
+            {t('close')}
+          </Button>
+        </PanelFooter>
+      </Panel>
+    </Modal>
+  );
+}
+
+LegalModal.propTypes = {
+  onClose: func,
+  page: oneOf(['cookies', 'terms-and-conditions', 'privacy-policy']).isRequired,
+};
+
+export default translate('translations')(LegalModal);

--- a/src/pages/home/components/LegalModal.scss
+++ b/src/pages/home/components/LegalModal.scss
@@ -1,0 +1,4 @@
+
+.panelRoot {
+  height: 100%;
+}

--- a/src/pages/static/TermsAndConditions.js
+++ b/src/pages/static/TermsAndConditions.js
@@ -56,21 +56,23 @@ function TermsAndConditions() {
         agree that Coding Coach shall not be responsible or liable, directly or indirectly, for any
         damage or loss caused or alleged to be caused by or in connection with use of or reliance on
         any such content, goods or services available on or through any such web sites or services.
-        <p>
-          We strongly advise you to read the terms and conditions and privacy policies of any
-          third-party web sites or services that you visit.
-        </p>
-        <h2>Termination</h2>
-        <p>
-          We may terminate or suspend your account immediately, without prior notice or liability,
-          for any reason whatsoever, including without limitation if you breach the Terms. Upon
-          termination, your right to use the Service will immediately cease. If you wish to
-          terminate your account, you may simply discontinue using the Service. Governing Law
-        </p>
-        <p>
-          These Terms shall be governed and construed in accordance with the laws of
-          Baden-Württemberg, Germany, without regard to its conflict of law provisions.
-        </p>
+      </p>
+      <p>
+        We strongly advise you to read the terms and conditions and privacy policies of any
+        third-party web sites or services that you visit.
+      </p>
+      <h2>Termination</h2>
+      <p>
+        We may terminate or suspend your account immediately, without prior notice or liability, for
+        any reason whatsoever, including without limitation if you breach the Terms. Upon
+        termination, your right to use the Service will immediately cease. If you wish to terminate
+        your account, you may simply discontinue using the Service. Governing Law
+      </p>
+      <p>
+        These Terms shall be governed and construed in accordance with the laws of
+        Baden-Württemberg, Germany, without regard to its conflict of law provisions.
+      </p>
+      <p>
         Our failure to enforce any right or provision of these Terms will not be considered a waiver
         of those rights. If any provision of these Terms is held to be invalid or unenforceable by a
         court, the remaining provisions of these Terms will remain in effect. These Terms constitute


### PR DESCRIPTION
# Details

## Description
Due to rector, the cookies disclaimer was not showing up. In order to show the legal modal from the cookies disclaimer I had to move the modal window to the home page, now the footer and the disclaimer receive a prop to open the modal window when the user clicks on the links.
