### PR TITLE
FIX: #190 Slack organization link should open in a new window

### DIFF
--- a/src/pages/home/Home.js
+++ b/src/pages/home/Home.js
@@ -86,7 +86,12 @@ class Home extends Component {
               <Interpolate
                 i18nKey="home-contact-text"
                 slackOrg={
-                  <a href={config.contact.SLACK_URL} className={styles.slackOrg}>
+                  <a
+                    href={config.contact.SLACK_URL}
+                    className={styles.slackOrg}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     {t('slack-org')}
                   </a>
                 }


### PR DESCRIPTION
# Details

## Description
Added target=_blank to open the link in a new tab

## Issue
#190 

