### PR TITLE
Fix: #188 UI shifts when a modal is opened

### DIFF
--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -3,20 +3,13 @@ import ReactDOM from 'react-dom';
 import styles from './modal.scss';
 
 class Modal extends React.Component {
-  static CLASS_OVERFLOW_HIDDEN = 'u-overflowHidden';
-
   constructor(props) {
     super(props);
     this.modal = document.createElement('div');
     document.body.appendChild(this.modal);
   }
 
-  componentDidMount() {
-    document.body.classList.add(Modal.CLASS_OVERFLOW_HIDDEN);
-  }
-
   componentWillUnmount() {
-    document.body.classList.remove(Modal.CLASS_OVERFLOW_HIDDEN);
     document.body.removeChild(this.modal);
   }
 

--- a/src/theme/base/_elements.scss
+++ b/src/theme/base/_elements.scss
@@ -15,9 +15,4 @@
       height: 100%;
     }
   }
-  
-  .u-overflowHidden {
-    height: 100vh;
-    overflow: hidden;
-  }
 }


### PR DESCRIPTION
# Details

## Description
Removed the style overflow hidden when the modal is open. I have tested it only on mac (Chrome, FF and safari). Need someone to confirm on windows as well.

## Issue
#188 
