### PR TITLE
removes this.state refrence inside of this.setState call Issue 209

### DIFF
--- a/src/components/modal/Modal.stories.js
+++ b/src/components/modal/Modal.stories.js
@@ -6,9 +6,7 @@ class ModalExperiment extends React.Component {
   state = { showModal: false };
 
   toggleModal = () => {
-    this.setState({
-      showModal: !this.state.showModal,
-    });
+    this.setState((prevState) => ({ showModal: !prevState.showModal }));
   };
 
   render() {

--- a/src/pages/home/Home.js
+++ b/src/pages/home/Home.js
@@ -34,12 +34,12 @@ class Home extends Component {
   };
 
   toggleModal = (page) => {
-    this.setState({
+    this.setState((prevState) => ({
       legal: {
-        show: !this.state.legal.show,
+        show: !prevState.legal.show,
         page,
       },
-    });
+    }));
   };
 
   render() {


### PR DESCRIPTION
# Details

## Description

Refactors 2 `this.setState` calls so that `this.state` is not used.

## Issue

Closes #209 
