### PR TITLE
Add .env.test file to keep DonateButton snapshots in sync

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+REACT_APP_PAYPAL_DONATE_BUTTON_ID=example-for-jest

--- a/src/components/footer/__tests__/__snapshots__/Donate.test.js.snap
+++ b/src/components/footer/__tests__/__snapshots__/Donate.test.js.snap
@@ -14,7 +14,7 @@ exports[`components/footer/DonateButton should render the donate button 1`] = `
   <input
     name="hosted_button_id"
     type="hidden"
-    value="3LA9RLHEXNZV6"
+    value="example-for-jest"
   />
   <input
     alt="footer-donate-paypal"


### PR DESCRIPTION
# Details

Originally discussed on Slack [here](https://coding-coach.slack.com/archives/CCQDTKZC2/p1546471427067000).

The PayPal Donate button uses the `REACT_APP_PAYPAL_DONATE_BUTTON_ID` that is currently specified in `.env`. It looks like a snapshot was pushed that uses somebody's local instance of that variable, so the snapshots are failing for anybody who doesn't have `REACT_APP_PAYPAL_DONATE_BUTTON_ID` set correctly.

## Description

Fortunately, `create-react-app` has a built-in hierarchy of `.env` files, [as documented here](https://facebook.github.io/create-react-app/docs/adding-custom-environment-variables#what-other-env-files-can-be-used). If we just add a `.env.test` file, we can have an instance of that global variable that only runs when `NODE_ENV` is `test`.

## Steps to QA

<!-- IF UNNECESSARY, REMOVE THIS SECTION. OTHERWISE, LIST STEPS SOMEONE CAN TAKE TO QA THE FEATURE OR BUG. -->

1. Run `yarn run test`
2. See that the tests pass.
3. If you want, open `.env.test` and change the value of `REACT_APP_PAYPAL_DONATE_BUTTON_ID`
4. Run `yarn run test` again.
5. See that the snapshot test for `DonateButton` fails.
