### PR TITLE
Remove PayPal button and other references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,3 @@ REACT_APP_FB_URL=https://www.facebook.com/codingcoachio/
 REACT_APP_INSTA_URL=https://www.instagram.com/codingcoach_io/
 REACT_APP_EMAIL=codingcoachio@gmail.com
 
-REACT_APP_PAYPAL_DONATE_BUTTON_ID=123abc

--- a/src/components/footer/DonateButton.js
+++ b/src/components/footer/DonateButton.js
@@ -3,24 +3,11 @@ import Config from 'config/constants';
 import Image from 'components/image/Image';
 
 /**
- * @TODO: We are removing this component for now, there are some
- * issues with the paypal account, once resolved we will put it back
- * in the footer
+ * @TODO: Add Patreon Button
  */
 function DonateButton() {
   return (
-    <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-      <input type="hidden" name="cmd" value="_s-xclick" />
-      <input type="hidden" name="hosted_button_id" value={Config.payments.paypal} />
-      <input
-        type="image"
-        src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"
-        border="0"
-        name="submit"
-        alt={'footer-donate-paypal'}
-      />
-      <Image alt={'footer-donate'} src="https://www.paypalobjects.com/de_DE/i/scr/pixel.gif" />
-    </form>
+    <div/>
   );
 }
 

--- a/src/components/footer/__tests__/__snapshots__/Donate.test.js.snap
+++ b/src/components/footer/__tests__/__snapshots__/Donate.test.js.snap
@@ -1,31 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/footer/DonateButton should render the donate button 1`] = `
-<form
-  action="https://www.paypal.com/cgi-bin/webscr"
-  method="post"
-  target="_top"
->
-  <input
-    name="cmd"
-    type="hidden"
-    value="_s-xclick"
-  />
-  <input
-    name="hosted_button_id"
-    type="hidden"
-    value="3LA9RLHEXNZV6"
-  />
-  <input
-    alt="footer-donate-paypal"
-    border="0"
-    name="submit"
-    src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"
-    type="image"
-  />
-  <img
-    alt="footer-donate"
-    src="https://www.paypalobjects.com/de_DE/i/scr/pixel.gif"
-  />
-</form>
-`;
+exports[`components/footer/DonateButton should render the donate button 1`] = `<div />`;

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -17,6 +17,5 @@ export default {
       'https://www.freeprivacypolicy.com/free-privacy-policy-generator.php',
   },
   payments: {
-    paypal: process.env.REACT_APP_PAYPAL_DONATE_BUTTON_ID || '123abc',
   },
 };


### PR DESCRIPTION
# Details
Removes PayPal integration
## Description
Removes PayPal button from footer and other references like .env.example and constants
<!-- ADD A DETAILED DESCRIPTION OF THE PULL REQUEST AND WHAT IT INTENDS TO SOLVE. -->

## Issue

<!-- IF UNNECESSARY, REMOVE THIS SECTION. OTHERWISE, REFERENCE THE GITHUB ISSUE, OR ISSUES, THIS PR PERTAINS TO. -->


<!-- Closing just one issue use this -->
<!-- For example, to close an issue numbered 123, you could use the phrase "Closes #123" -->
Closes https://github.com/Coding-Coach/coding-coach/issues/272

<!-- Or, Closing multiple issues -->
<!-- To close multiple issues, preface each issue reference with "closes" keywords -->
<!-- For example, `This closes #34, closes #23, and closes #42` would close issues #34, #23 and #42 -->

