### PR TITLE
Cookie policy sense-check/grammar-check

### DIFF
--- a/src/pages/static/CookiesPolicy.md
+++ b/src/pages/static/CookiesPolicy.md
@@ -1,29 +1,24 @@
 # What Are Cookies
 
-As is common practice with almost all professional websites this site uses cookies, which are tiny files that are downloaded to your computer, to improve your experience. This page describes what information they gather, how we use it and why we sometimes need to store these cookies. We will also share how you can prevent these cookies from being stored however this may downgrade or 'break' certain elements of the sites functionality.
+As is common practice with almost all professional websites this site uses cookies, which are tiny text files that are downloaded to your computer, to improve your experience. This information describes what they contain, how we use it and why we sometimes need to store these cookies. This information also covers how you can prevent these cookies from being stored; this may, however, downgrade or 'break' certain elements of the site's functionality.
 
-For more general information on cookies see the Wikipedia article on HTTP Cookies.</p>
-
-## How We Use Cookies
-
-We use cookies for a variety of reasons detailed below. Unfortunately in most cases there are no industry standard options for disabling cookies without completely disabling the functionality and features they add to this site. It is recommended that you leave on all cookies if you are not sure whether you need them or not in case they are used to provide a service that you use.
+For more general information on cookies see the [Wikipedia article on HTTP Cookies](https://en.wikipedia.org/wiki/HTTP_cookie).
 
 ## Disabling Cookies
 
-You can prevent the setting of cookies by adjusting the settings on your browser (see your browser Help for how to do this). Be aware that disabling cookies will affect the functionality of this and many other websites that you visit. Disabling cookies will usually result in also disabling certain functionality and features of the this site. Therefore it is recommended that you do not disable cookies.
+You can prevent the setting of cookies by adjusting the settings on your browser (see your browser's help for instructions on how to do this). Be aware that disabling cookies will affect the functionality of this and many other websites that you visit; disabling cookies will usually result in also disabling certain functionality and features of the site. It is recommended that you leave cookies enabled.
 
 ## The Cookies We Set
 
 *  **Account related cookies** - If you create an account with us then we will use cookies for the management of the signup process and general administration. These cookies will usually be deleted when you log out however in some cases they may remain afterwards to remember your site preferences when logged out.
-* **Login related cookies** - We use cookies when you are logged in so that we can remember this fact. This prevents you from having to log in every single time you visit a new page. These cookies are typically removed or cleared when you log out to ensure that you can only access restricted features and areas when logged in.
+* **Login related cookies** - We use cookies to indicate whether you are logged in. This prevents you from having to log in every single time you visit a new page. These cookies are typically removed or cleared when you log out to ensure that you can only access restricted features and areas when logged in.
 
 ## Third Party Cookies
 
-In some special cases we also use cookies provided by trusted third parties. The following section details which third party cookies you might encounter through this site.
+In some special cases we also use cookies provided by trusted third parties, as detailed below:
 
-* This site uses Google Analytics which is one of the most widespread and trusted analytics solution on the web for helping us to understand how you use the site and ways that we can improve your experience. These cookies may track things such as how long you spend on the site and the pages that you visit so we can continue to produce engaging content.
-* For more information on Google Analytics cookies, see the official Google Analytics page.
+* This site uses Google Analytics which is one of the most widespread and trusted analytics solution on the web for helping us to understand how you use the site and ways that we can improve your experience. These cookies may track things such as how long you spend on the site and the pages that you visit so we can continue to produce engaging content. For more information on the cookies set by Google Analytics, see [Google's Analytics privacy statement](https://support.google.com/analytics/answer/6004245).
 
 ## More Information
 
-Hopefully that has clarified things for you and as was previously mentioned if there is something that you aren't sure whether you need or not it's usually safer to leave cookies enabled in case it does interact with one of the features you use on our site. This Cookies Policy was created with the help of the GDPR Cookies Policy Generator However if you are still looking for more information then you can contact us through one of our preferred contact methods: <codingcoachio@gmail.com>
+If you are unsure of whether certain cookies are required for the correct operation of the site, we recommend you leave the cookies in question enabled to avoid inadvertently degrading your experience. If you are still looking for more information then you can contact us via email at <codingcoachio@gmail.com>.


### PR DESCRIPTION
 - General grammar check
 - Copy-edited for reading flow
 - Dropped "How we use cookies", because it's just a repeat of "leave it if you're not sure"; the relevant information is in "The Cookies We Set".
 - Removed "GDPR Cookie Policy Generator" text watermark.
