### PR TITLE
Toggle classNames on body when modal open/close

### DIFF
--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -9,8 +9,15 @@ class Modal extends React.Component {
     document.body.appendChild(this.modal);
   }
 
+  componentDidMount() {
+    document.body.classList.add('overflow-hidden');
+  }
+
   componentWillUnmount() {
-    document.body.removeChild(this.modal);
+    const { body } = document;
+
+    body.removeChild(this.modal);
+    body.classList.remove('overflow-hidden');
   }
 
   render() {


### PR DESCRIPTION
# Details

## Description

This PR aims to don't let the scroll of the `body` tag when a modal is opened, and let it back when the modal is closed

## Steps to QA

- [ ] Open/Close modal must hide/show the `body` scrollbar as a visual proof of not let the scroll happen

## Screenshots

![screenshot_2019-01-10_11-52-23](https://user-images.githubusercontent.com/478407/50987096-39613080-14ce-11e9-8130-148f6bfb8ec2.png)
![screenshot_2019-01-10_11-55-23](https://user-images.githubusercontent.com/478407/50987221-a1b01200-14ce-11e9-9e7f-2c5e1673c9a3.png)


## Issue
Closes #276
