### PR TITLE
Solving static height of Privacy Policy modal. Fixes #186

### DIFF
--- a/src/components/modal/Modal.js
+++ b/src/components/modal/Modal.js
@@ -39,7 +39,7 @@ class Modal extends React.Component {
           onClick={(e) => e.stopPropagation()}
           className={classNames(
             'relative pt-10 pb-10 pl-5 pr-5',
-            `w-full h-full`,
+            `w-full`,
             'md:w-auto md:max-w-md lg:max-w-lg xl:max-w-xl',
           )}
         >

--- a/src/components/panel/Panel.js
+++ b/src/components/panel/Panel.js
@@ -47,9 +47,7 @@ export function PanelHeader({ children }) {
 }
 
 export function PanelContent({ children }) {
-  return (
-    <div className="p-6 overflow-y-auto calcheight-40 panel-content font-content">{children}</div>
-  );
+  return <div className="p-6 overflow-y-auto panel-content font-content">{children}</div>;
 }
 
 export function PanelFooter({ children }) {

--- a/tailwind.js
+++ b/tailwind.js
@@ -933,6 +933,7 @@ module.exports = {
       const margin = config('margin');
       const base = {
         '.panel-content': {
+          maxHeight: 'calc(90vh - 9rem)',
           lineHeight: 'normal',
           h2: {
             margin: `${margin[3]} 0`,


### PR DESCRIPTION
# Details

## Description

### Allows the modal to adapt to the height of its content

Removed the fixed height to 100% of the modal and set a maximum height of the panel content to avoid content overflowing when exceeds the screen height.

* Removed h-full class on the modal 
* Removed the class calcheight-40 of the panel-content on Panel Component
* Added the property max-height: calc(90vh - 9rem) to the panel-content class on tailwind.js file.

## Screenshots

![doblemodal](https://user-images.githubusercontent.com/3359663/51775560-70eaf200-20f6-11e9-852d-273c5055d157.PNG)

## Issue

Closes #186