### PR TITLE
updated CodeOfCoduct as per issue 314

### DIFF
--- a/src/pages/static/CodeOfConduct.md
+++ b/src/pages/static/CodeOfConduct.md
@@ -17,6 +17,8 @@ Harassment includes but is not limited to:
   * Deliberate “outing” of any aspect of a person’s identity without their consent except as necessary to protect vulnerable people from intentional abuse.
   * Publication of non-harassing private communication.
 
+We value integrity here at Coding Coach. As such, mentees may not ask for solutions to technical interview take home assessments. We're happy to mentor you in the process of solving difficult questions, but will not provide you with solutions to your assessments as they are meant to reflect your personal skill set.
+
 Members who violate this code of conduct will be approached by someone of the Coding Coach leadership team and asked to stop immediately. Members may also be banned from the Coding Coach slack, blocked on social media, and removed from the website. 
 
 If someone makes you or anyone else feel unsafe or unwelcome, please report it as soon as possible. To report an incident of harassment, anonymously or otherwise, please fill out [our report form](https://forms.gle/bcSWqNNcsdo3zDD17).


### PR DESCRIPTION
# Details

## Description

Adds the following text to the Code Of Conduct:

> "We value integrity here at Coding Coach. As such, mentees may not ask for solutions to technical interview take home assessments. We're happy to mentor you in the process of solving difficult questions, but will not provide you with solutions to your assessments as they are meant to reflect your personal skill set."

## Issue

Closes #314 