### PR TITLE
Fixed broken navigation to 'about', 'contact' headings

### DIFF
--- a/src/components/navbar/Navbar.js
+++ b/src/components/navbar/Navbar.js
@@ -26,13 +26,13 @@ function Navbar() {
         <NavLink to="/openings/frontend-jr">
           <Trans id="home.mentors.openings" />
         </NavLink>
-        <NavLink to="#about">
+        <NavLink to="/#about">
           <Trans id="home.about.title" />
         </NavLink>
-        <NavLink to="#mission" className="hidden md:block">
+        <NavLink to="/#mission" className="hidden md:block">
           <Trans id="home.mission.title" />
         </NavLink>
-        <NavLink to="#contact" className="hidden md:block">
+        <NavLink to="/#contact" className="hidden md:block">
           <Trans id="home.contact.title" />
         </NavLink>
       </div>


### PR DESCRIPTION
# Details

## Description

Navigation to the mentioned pages/headings does not work if the user is on the mock openings page.

## Steps to QA

- Navigate to the page 'Mock openings'.
- Click on one of About, Contact or Mission.
- User should be navigated to the clicked pages.

## Issue

This closes [#323](https://github.com/Coding-Coach/coding-coach/issues/323)