### PR TITLE
ensure we're on the root before we anchor link

### DIFF
--- a/src/components/navbar/Navbar.js
+++ b/src/components/navbar/Navbar.js
@@ -26,13 +26,13 @@ function Navbar() {
         <NavLink to="/openings/frontend-jr">
           <Trans id="home.mentors.openings" />
         </NavLink>
-        <NavLink to="#about">
+        <NavLink to="/#about">
           <Trans id="home.about.title" />
         </NavLink>
-        <NavLink to="#mission" className="hidden md:block">
+        <NavLink to="/#mission" className="hidden md:block">
           <Trans id="home.mission.title" />
         </NavLink>
-        <NavLink to="#contact" className="hidden md:block">
+        <NavLink to="/#contact" className="hidden md:block">
           <Trans id="home.contact.title" />
         </NavLink>
       </div>


### PR DESCRIPTION
# Details

## Description

Fix the nav link anchors that don't work as expected beyond the home page.

## Steps to QA

- [ ] Open home page
- [ ] Click on `Mock Openings` link in the nav
- [ ] Observe that the URL has changed to `/openings/frontend-jr`
- [ ] Click on `About` link in the nav
- [ ] Observe that the URL has changed to `/#About` and the About section appears as expected
- [ ] Click on `Contact` link in the nav
- [ ] Observe that the URL has changed to `/#Contact` and the Contact section appears as expected
- [ ] Click on `Mission` link in the nav
- [ ] Observe that the URL has changed to `/#Mission` and the Mission section appears s expected


## Issue

Closes #323

## Notes
Think of how awesome this PR could have been if it included `cypress` tests proving that the job was done correctly.  No need to detail the QA steps, and no fear of regression.