### PR TITLE
Fix home tests; Add test coverage by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:ssr": "react-snap",
     "deploy": "gh-pages -d build",
     "lint": "eslint src/",
-    "test": "react-scripts test --env=jsdom",
+    "test": "react-scripts test --env=jsdom --coverage",
     "test:staged": "cross-env CI=true react-scripts test --env=jsdom --findRelatedTests",
     "eject": "react-scripts eject",
     "precommit": "lint-staged",

--- a/src/config/i18n/index.js
+++ b/src/config/i18n/index.js
@@ -1,5 +1,5 @@
-import en from './en/messages.js';
-import es from './es/messages.js';
-import fr from './fr/messages.js';
+import en from './en/messages.json';
+import es from './es/messages.json';
+import fr from './fr/messages.json';
 
 export const catalogs = { en, es, fr };

--- a/src/pages/home/__tests__/home.test.js
+++ b/src/pages/home/__tests__/home.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from 'react-testing-library';
 import { I18nProvider } from '@lingui/react';
+import { t } from '@lingui/macro';
 import { catalogs } from 'config/i18n';
 import Home from '../Home';
 
@@ -11,7 +12,7 @@ test('renders the Home page', () => {
     </I18nProvider>,
   );
 
-  expect(getByText('About')).toBeDefined();
-  expect(getByText('Mission')).toBeDefined();
-  expect(getByText('Contact')).toBeDefined();
+  expect(getByText('home.about.title')).toBeDefined();
+  expect(getByText('home.mission.title')).toBeDefined();
+  expect(getByText('home.contact.title')).toBeDefined();
 });

--- a/src/pages/home/__tests__/home.test.js
+++ b/src/pages/home/__tests__/home.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render } from 'react-testing-library';
 import { I18nProvider } from '@lingui/react';
-import { t } from '@lingui/macro';
 import { catalogs } from 'config/i18n';
 import Home from '../Home';
 


### PR DESCRIPTION
# Details
Some tests we broken after I just forked and cloned.

## Description
This PR fixes a couple of tests and adds the `coverage` flag by default to the test script

## Notes
Currently the test coverage is ~14% which is not that good. May I suggest adding more tests and snapshots as well?