### PR TITLE
fix(animation): change param passed to nav function

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "react-ga": "^2.5.7",
     "react-scripts": "2.1.1",
     "remark": "^10.0.1",
-    "remark-react": "^5.0.0"
+    "remark-react": "^5.0.0",
+    "smoothscroll-polyfill": "^0.4.4"
   },
   "husky": {
     "hooks": {

--- a/src/components/navbar/Navbar.js
+++ b/src/components/navbar/Navbar.js
@@ -1,17 +1,27 @@
 import React from 'react';
 import { Trans } from '@lingui/macro';
 import classNames from 'classnames';
+import smoothscroll from 'smoothscroll-polyfill';
+
+smoothscroll.polyfill();
 
 const handleClickOnNavigation = (id) => {
   return (event) => {
-    const el = document.getElementById(id);
+    // Strips off extra characters, /#, since
+    // getElementById auto adds #
+    const anchor = id.replace('/#', '');
+
+    const el = document.getElementById(anchor);
 
     if (el) {
       event.preventDefault();
       el.scrollIntoView({
         behavior: 'smooth',
       });
-      window.history.pushState({}, '', `/#${id}`);
+
+      // Remove /#, if not url becomes /#/#
+      // if you just remove # then pushState will error
+      window.history.pushState({}, '', `${id}`);
     }
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10599,6 +10599,11 @@ slice-ansi@1.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
 
+smoothscroll-polyfill@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz#3a259131dc6930e6ca80003e1cb03b603b69abf8"
+  integrity sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"


### PR DESCRIPTION
# Details
The header links jump instead of scrolling on click. Add polyfill to support Safari and Firefox.

## Description
When clicking on the nav links there is no smooth scrolling, it jumps like a normal anchor.  

## Steps to QA
- [x] `yarn` to install smoothscroll polyfill
- [x] Test with Chrome, Safari, Firefox, and Edge
- [x] Test with window sizes/resolutions ( can also test but zooming in/out in the browser )

## Issue
#195 #201 #327 


Closes #327 