### PR TITLE
Add Fabian Gündel to contributors

### DIFF
--- a/content/contributors/fabian-guendel.md
+++ b/content/contributors/fabian-guendel.md
@@ -1,0 +1,5 @@
+---
+name: Fabian Gündel
+avatar: https://avatars0.githubusercontent.com/u/5798652?s=200
+link: https://mentors.codingcoach.io/?name=Fabian+Gündel
+---


### PR DESCRIPTION
Hi!

I would love to be added to the contributors part on the About page.
This is the change I implemented for the Mentors page:  
https://github.com/Coding-Coach/find-a-mentor/pull/371